### PR TITLE
fix typo

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script>
-  import Navbar from '../components/Navbar'
+  import Navbar from '../components/NavBar'
 
   export default {
     components: {


### PR DESCRIPTION
I found error the below situation.
 1. "git clone" your code in my machine.
 2. run "npm install".
 3. run "npm run dev".
 4. Below error occurs.

` ERROR  Failed to compile with 1 errors                               3:20:33 PM

This relative module was not found:

* ../components/Navbar in ./node_modules/babel-loader/lib??ref--2-0!./node_modules/vue-loader/lib??vue-loader-options!./layouts/default.vue?vue&type=script&lang=js&
`

This error is fixed by my commit.

Please adopt my pull request.

# I'm sorry that I'm not good at english. :_)